### PR TITLE
Add support for the profound programmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "slack 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 authors = ["Martin Conte Mac Donell <martin@lyft.com>"]
 
 [dependencies]
-slack = "*"
-regex = "*"
-log = "*"
 hyper = "*"
+log = "*"
+rand = "*"
+regex = "*"
 rustc-serialize = "*"
+slack = "*"

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -7,6 +7,7 @@ use slack::{User, RtmClient};
 pub mod echo;
 pub mod meme;
 pub mod slackbot;
+pub mod profound;
 
 pub struct Message {
     pub user: User,

--- a/src/listener/profound.rs
+++ b/src/listener/profound.rs
@@ -1,9 +1,13 @@
 extern crate hyper;
 extern crate slack;
+extern crate rand;
 
 use hyper::Client;
 use listener::{MessageListener, Message};
 use regex::Regex;
+use rustc_serialize::json;
+use self::rand::Rng;
+use std::io::Read;
 
 
 /// Listens for the words `be profound` and posts a random profound programmer link
@@ -11,6 +15,24 @@ use regex::Regex;
 /// Example @yobot be profound
 pub struct ProfoundListener {
     regex: Regex,
+}
+
+#[derive(RustcDecodable)]
+struct ProfoundPost {
+    photo_url_1280: String,
+}
+
+#[derive(RustcDecodable)]
+struct ProfoundResponse {
+    posts: Vec<ProfoundPost>,
+}
+
+impl ProfoundResponse {
+    fn new() -> ProfoundResponse {
+        ProfoundResponse {
+            posts: Vec::new(),
+        }
+    }
 }
 
 impl ProfoundListener {
@@ -32,12 +54,21 @@ impl MessageListener for ProfoundListener {
 
     fn handle(&self, message: &Message, cli: &slack::RtmClient) {
         let client = Client::new();
-        let url = "http://theprofoundprogrammer.com/random";
-        let text = match client.get(url).send() {
-            Ok(response) => response.url.serialize(),
-            Err(_) => "Maybe next time".to_owned(),
-        };
+        let mut rng = rand::thread_rng();
+        let index = rng.next_u32() % 116;
+        let url = format!("http://theprofoundprogrammer.com/api/read/json?debug=1&num=1&type=photo&start={}", index);
+        if let Ok(mut response) = client.get(&url).send() {
+            let mut body = String::new();
+            let _ = response.read_to_string(&mut body);
+            let parts: Vec<&str> = body.split("-").collect();
+            let string = parts.join("_");
+            let response = json::decode(&string).unwrap_or(ProfoundResponse::new());
+            if let Some(post) = response.posts.first() {
+                let _ = cli.send_message(&message.channel, &post.photo_url_1280);
+                return;
+            }
+        }
 
-        let _ = cli.send_message(&message.channel, &text);
+        let _ = cli.send_message(&message.channel, "Maybe next time");
     }
 }

--- a/src/listener/profound.rs
+++ b/src/listener/profound.rs
@@ -1,0 +1,43 @@
+extern crate hyper;
+extern crate slack;
+
+use hyper::Client;
+use listener::{MessageListener, Message};
+use regex::Regex;
+
+
+/// Listens for the words `be profound` and posts a random profound programmer link
+///
+/// Example @yobot be profound
+pub struct ProfoundListener {
+    regex: Regex,
+}
+
+impl ProfoundListener {
+    pub fn new() -> ProfoundListener {
+        ProfoundListener {
+            regex: Regex::new(r"be profound").unwrap(),
+        }
+    }
+}
+
+impl MessageListener for ProfoundListener {
+    fn help(&self) -> String {
+        "`be profound`: Post a random profound programmer image".to_owned()
+    }
+
+    fn re(&self) -> &Regex {
+        &self.regex
+    }
+
+    fn handle(&self, message: &Message, cli: &slack::RtmClient) {
+        let client = Client::new();
+        let url = "http://theprofoundprogrammer.com/random";
+        let text = match client.get(url).send() {
+            Ok(response) => response.url.serialize(),
+            Err(_) => "Maybe next time".to_owned(),
+        };
+
+        let _ = cli.send_message(&message.channel, &text);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,5 +17,6 @@ fn main() {
     Yobot::new()
         .add_listener(meme::MemeListener::new())
         .add_listener(slackbot::SlackbotListener::new())
+        .add_listener(profound::ProfoundListener::new())
         .connect();
 }


### PR DESCRIPTION
This adds a `be profound` command that posts a random profound
programmer image in the channel. Unfortunately there doesn't seem to be
any larger list we can lean on for specifics. Although we could come up
with a large map if we wanted to.
